### PR TITLE
Add rSEEG training notebook flow and conditional FIF loader

### DIFF
--- a/conf/dataset/fif_data_example.yaml
+++ b/conf/dataset/fif_data_example.yaml
@@ -1,9 +1,14 @@
 # @package _group_
+self: fif_data
 _target_: ntd.datasets.FIFDataLoader
 name: fif_example
 # Path to the directory containing .fif files or a single .fif file
 # Example: '/path/to/your/eeg/data/' or '/path/to/your/eeg/data/subject1.fif'
 file_path: ???
+
+# Signal length (number of time points per epoch) expected by the network.
+# Set this to match the epoch length in your .fif files.
+signal_length: 1000
 
 # n_channels, sfreq, and n_times (signal length in samples) are inferred from the first valid .fif file.
 # All subsequent .fif files must match these inferred parameters, otherwise they will be skipped.
@@ -13,7 +18,7 @@ file_path: ???
 # If n_epochs is set to null (YAML for None) or 0, all available epochs from each file will be loaded.
 # Example: n_epochs: 20 # Loads max 20 epochs per file.
 # Example: n_epochs: null # Loads all epochs from all files.
-n_epochs: 20 
+n_epochs: 20
 
 # Set to True to enable conditioning on subject ID.
 # Subject IDs are derived from filenames if multiple files are loaded from a directory.
@@ -22,6 +27,14 @@ condition_on_subject_id: False
 # Class labels are extracted from filenames using the convention: CLASSLABEL_SUBJECTID_*.fif
 # e.g., PATIENT_S001_data.fif, CONTROL_S002_data.fif
 condition_on_class_label: False
+
+# When enabling conditioning above, set network.cond_dim to
+# the total number of one-hot channels (num_classes + num_subjects)
+# so the AdaConv model can accept the conditioning tensor.
+
+# Train/test split fraction and random seed, mirroring other dataset configs.
+train_test_split: 1.0
+split_seed: 0
 
 # Example for conditional generation on class_label:
 # condition_on_class_label: True

--- a/notebooks/example_ner_notebook.ipynb
+++ b/notebooks/example_ner_notebook.ipynb
@@ -1,294 +1,370 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Notebook for training a DDPM on the BCI Challenge @ NER 2015\n",
-    "\n",
-    "This notebooks trains a DDPM from scratch to generate synthetic EEG trials.\n",
-    "The generated trials can then be plotted and compared to the real data.\n",
-    "The data is provided in the `data` folder."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Train a DDPM on resting-state EEG epochs (\\*.fif)\n",
+        "\n",
+        "This notebook mirrors the original NER example but is tailored to epoched resting-state EEG stored as MNE `Epochs`.\n",
+        "It relies on the `FIFDataLoader`, which ingests `.fif` files exported from your preprocessing pipeline and can optionally\n",
+        "condition on subject IDs or diagnosis labels.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Prepare your epochs as .fif files\n",
+        "\n",
+        "* Export each subject's preprocessed epochs to a standalone `.fif` file (e.g., using `epochs.save('CLASS_SUBJECTID_epochs.fif')`).\n",
+        "* If you want class conditioning, follow the `CLASS_SUBJECTID_*.fif` naming convention (e.g., `DEMENTIA_S001_epochs.fif`).\n",
+        "* Keep epoch lengths consistent across files; the loader will skip files that do not match the inferred `sfreq`, `n_channels`, or `n_times`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Example: exporting an MNE Epochs object for one subject\n",
+        "# epochs: mne.Epochs = ...  # your preprocessed epochs\n",
+        "# class_label = 'DEMENTIA'\n",
+        "# subject_id = 'S001'\n",
+        "# epochs.save(f'/path/to/epochs_dir/{class_label}_{subject_id}_epochs.fif', overwrite=True)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import logging\n",
+        "from pathlib import Path\n",
+        "\n",
+        "import matplotlib.pyplot as plt\n",
+        "import mne\n",
+        "import numpy as np\n",
+        "import torch\n",
+        "from hydra import compose, initialize\n",
+        "from omegaconf import OmegaConf\n",
+        "from pandas import read_csv\n",
+        "\n",
+        "from ntd.datasets import FIFDataLoader\n",
+        "from ntd.train_diffusion_model import training_and_eval_pipeline\n",
+        "from ntd.utils.plotting_utils import (\n",
+        "    basic_plotting,\n",
+        "    plot_overlapping_signal,\n",
+        "    plot_sd,\n",
+        ")\n",
+        "from ntd.utils.utils import l2_distances\n",
+        "\n",
+        "logging.basicConfig(level=logging.INFO)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Create the config for rSEEG\n",
+        "\n",
+        "Override the config to point to your `.fif` files and to match your data dimensions.\n",
+        "Set `condition_on_class_label` to `True` if you want to condition on diagnosis (and adjust `network.cond_dim`).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "data_path = '/path/to/epochs_dir'  # directory containing your exported .fif files\n",
+        "condition_on_class_label = True\n",
+        "condition_on_subject_id = False\n",
+        "\n",
+        "with initialize(version_base=None, config_path='../conf'):\n",
+        "    cfg = compose(\n",
+        "        config_name='config',\n",
+        "        overrides=[\n",
+        "            'dataset=fif_data_example',\n",
+        "            f'dataset.file_path={data_path}',\n",
+        "            'base.tag=rseeg_unconditional',\n",
+        "            'base.wandb_mode=disabled',\n",
+        "            'base.save_path=null',\n",
+        "            'optimizer.num_epochs=1000',\n",
+        "            'optimizer.lr=0.0004',\n",
+        "            'optimizer.train_batch_size=16',\n",
+        "            'network.signal_channel=19',\n",
+        "            'network.in_kernel_size=65',\n",
+        "            'network.out_kernel_size=65',\n",
+        "            'network.slconv_kernel_size=65',\n",
+        "            'network.num_scales=1',\n",
+        "            'network.hidden_channel=32',\n",
+        "            'network.num_off_diag=32',\n",
+        "            'network.use_pos_emb=True',\n",
+        "            '+experiments/generate_samples=generate_samples',\n",
+        "        ],\n",
+        "    )\n",
+        "\n",
+        "# Update conditioning flags before training\n",
+        "cfg.dataset.condition_on_class_label = condition_on_class_label\n",
+        "cfg.dataset.condition_on_subject_id = condition_on_subject_id\n",
+        "\n",
+        "# Peek at the dataset once to infer dimensions and adjust cond_dim / signal_length\n",
+        "preview_dataset = FIFDataLoader(\n",
+        "    file_path=cfg.dataset.file_path,\n",
+        "    n_epochs=cfg.dataset.n_epochs,\n",
+        "    condition_on_class_label=cfg.dataset.condition_on_class_label,\n",
+        "    condition_on_subject_id=cfg.dataset.condition_on_subject_id,\n",
+        ")\n",
+        "cfg.dataset.signal_length = preview_dataset.n_times\n",
+        "cfg.network.signal_channel = preview_dataset.n_channels\n",
+        "if preview_dataset.cond is not None:\n",
+        "    cfg.network.cond_dim = preview_dataset.cond_dim\n",
+        "\n",
+        "# Generate as many samples as we have training epochs by default\n",
+        "cfg.generate_samples.num_samples = len(preview_dataset)\n",
+        "\n",
+        "print(OmegaConf.to_yaml(cfg))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Train the model and generate samples\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "diffusion_model, samples = training_and_eval_pipeline(cfg)\n",
+        "samples_numpy = samples.numpy()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Load the same dataset for evaluation/plotting\n",
+        "rseeg_dataset = FIFDataLoader(\n",
+        "    file_path=cfg.dataset.file_path,\n",
+        "    n_epochs=cfg.dataset.n_epochs,\n",
+        "    condition_on_class_label=cfg.dataset.condition_on_class_label,\n",
+        "    condition_on_subject_id=cfg.dataset.condition_on_subject_id,\n",
+        ")\n",
+        "raw_numpy = rseeg_dataset.data_array_np\n",
+        "\n",
+        "assert samples_numpy.shape[1:] == raw_numpy.shape[1:]\n",
+        "num_trials, num_channels, sig_length = raw_numpy.shape\n",
+        "fs = rseeg_dataset.sfreq\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Plot some random real and generated samples\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "rand_id = np.random.randint(len(samples_numpy))\n",
+        "print(rand_id)\n",
+        "offset = -1.1\n",
+        "fig, ax = plt.subplots()\n",
+        "plot_overlapping_signal(\n",
+        "    fig,\n",
+        "    ax,\n",
+        "    sig=raw_numpy[rand_id] + offset * np.arange(num_channels)[:, np.newaxis],\n",
+        "    colors=['dimgrey'],\n",
+        ")\n",
+        "basic_plotting(\n",
+        "    fig,\n",
+        "    ax,\n",
+        "    y_ticks=[],\n",
+        "    x_lim=(0, sig_length),\n",
+        "    x_ticks=[0, sig_length],\n",
+        "    x_ticklabels=[0, sig_length / fs],\n",
+        "    x_label='time [s]',\n",
+        ")\n",
+        "fig.tight_layout()\n",
+        "plt.show()\n",
+        "\n",
+        "fig, ax = plt.subplots()\n",
+        "plot_overlapping_signal(\n",
+        "    fig,\n",
+        "    ax,\n",
+        "    samples_numpy[rand_id] + offset * np.arange(num_channels)[:, np.newaxis],\n",
+        "    colors=['black'],\n",
+        ")\n",
+        "basic_plotting(\n",
+        "    fig,\n",
+        "    ax,\n",
+        "    y_ticks=[],\n",
+        "    x_lim=(0, sig_length),\n",
+        "    x_ticks=[0, sig_length],\n",
+        "    x_ticklabels=[0, sig_length / fs],\n",
+        "    x_label='time [s]',\n",
+        ")\n",
+        "fig.tight_layout()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Plot the power spectral density\n",
+        "\n",
+        "Red is generated, black is real. Pointwise median and 25% / 75% percentiles are shown.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "fig, axs = plt.subplots(num_channels // 10 + 1, 10, figsize=(45, 25))\n",
+        "for idx in range(num_channels):\n",
+        "    plot_sd(\n",
+        "        fig=fig,\n",
+        "        ax=axs[idx // 10, idx % 10],\n",
+        "        arr_one=raw_numpy[:, idx, :],\n",
+        "        arr_two=samples_numpy[:, idx, :],\n",
+        "        fs=fs,\n",
+        "        nperseg=sig_length,\n",
+        "        agg_function=np.median,\n",
+        "        with_quantiles=True,\n",
+        "        x_ss=slice(0, int(fs // 2)),\n",
+        "        color_one='black',\n",
+        "        color_two='C3',\n",
+        "    )\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Plot the evoked potentials\n",
+        "\n",
+        "For all channels. Red is generated, black is real. Mean and standard deviation are shown.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "fig, axs = plt.subplots(num_channels // 5 + 1, 5, figsize=(45, 45))\n",
+        "time_axis = np.arange(sig_length) / fs\n",
+        "for idx in range(num_channels):\n",
+        "    axs[idx // 5, idx % 5].fill_between(\n",
+        "        time_axis,\n",
+        "        np.quantile(raw_numpy[:, idx, :], 0.1, axis=0),\n",
+        "        np.quantile(raw_numpy[:, idx, :], 0.9, axis=0),\n",
+        "        color='black',\n",
+        "        alpha=0.2,\n",
+        "    )\n",
+        "    axs[idx // 5, idx % 5].fill_between(\n",
+        "        time_axis,\n",
+        "        np.quantile(samples_numpy[:, idx, :], 0.1, axis=0),\n",
+        "        np.quantile(samples_numpy[:, idx, :], 0.9, axis=0),\n",
+        "        color='C3',\n",
+        "        alpha=0.2,\n",
+        "    )\n",
+        "    axs[idx // 5, idx % 5].plot(\n",
+        "        time_axis,\n",
+        "        np.mean(raw_numpy[:, idx, :], axis=0),\n",
+        "        color='black',\n",
+        "    )\n",
+        "    axs[idx // 5, idx % 5].plot(\n",
+        "        time_axis,\n",
+        "        np.mean(samples_numpy[:, idx, :], axis=0),\n",
+        "        color='C3',\n",
+        "    )\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Plot the topomaps\n",
+        "\n",
+        "This example reuses channel locations from your `.fif` files (or a custom CSV).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Option 1: read channel names/montage from the first .fif file\n",
+        "first_fif = sorted(Path(cfg.dataset.file_path).glob('*.fif'))[0]\n",
+        "epochs_info = mne.read_epochs(first_fif, preload=False, verbose='WARNING').info\n",
+        "info = mne.create_info(\n",
+        "    ch_names=epochs_info.ch_names, sfreq=fs, ch_types='eeg'\n",
+        ")\n",
+        "info.set_montage(epochs_info.get_montage())\n",
+        "\n",
+        "# Option 2: replace the block above with a CSV like in the original example\n",
+        "# csv_path = '../data/CorrectedChannelsLocation.csv'\n",
+        "# chan_info = read_csv(csv_path)\n",
+        "# montage = mne.channels.make_standard_montage('standard_1020')\n",
+        "# info = mne.create_info(ch_names=list(chan_info['Labels']), sfreq=fs, ch_types='eeg')\n",
+        "# info.set_montage(montage)\n",
+        "\n",
+        "times = np.linspace(0, sig_length / fs, num=5, endpoint=False)\n",
+        "for samples in [raw_numpy, samples_numpy]:\n",
+        "    evoked = mne.EvokedArray(samples.mean(0), info)\n",
+        "    evoked.plot_topomap(\n",
+        "        times,\n",
+        "        ch_type='eeg',\n",
+        "        scalings=1.0,\n",
+        "        vlim=(-0.5, 0.5),\n",
+        "        image_interp='cubic',\n",
+        "        colorbar=False,\n",
+        "        res=300,\n",
+        "        size=1.5,\n",
+        "    )\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "neuro_diff",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.10"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import logging\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import mne\n",
-    "import numpy as np\n",
-    "import torch\n",
-    "from hydra import compose, initialize\n",
-    "from omegaconf import OmegaConf\n",
-    "from pandas import read_csv\n",
-    "\n",
-    "from ntd.datasets import NER_BCI\n",
-    "from ntd.train_diffusion_model import training_and_eval_pipeline\n",
-    "from ntd.utils.plotting_utils import (\n",
-    "    basic_plotting,\n",
-    "    plot_overlapping_signal,\n",
-    "    plot_sd,\n",
-    ")\n",
-    "from ntd.utils.utils import l2_distances\n",
-    "\n",
-    "logging.basicConfig(level=logging.INFO)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Create the config\n",
-    "\n",
-    "If you want to make changes to the network architecture or optimization, override the config in `overrides`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data_path = \"../data\"\n",
-    "with initialize(version_base=None, config_path=\"../conf\"):\n",
-    "    cfg = compose(\n",
-    "        config_name=\"config\",\n",
-    "        overrides=[\n",
-    "            \"base.experiment=ner_example\",\n",
-    "            \"base.tag=unconditional_wn\",\n",
-    "            \"base.wandb_mode=disabled\",\n",
-    "            f\"dataset.filepath={data_path}\",\n",
-    "            \"base.save_path=null\",\n",
-    "            \"optimizer.num_epochs=1000\",\n",
-    "            \"optimizer.lr=0.0004\",\n",
-    "            \"+experiments/generate_samples=generate_samples\",\n",
-    "        ],\n",
-    "    )\n",
-    "    print(OmegaConf.to_yaml(cfg))\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Train the model and and generate samples"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "diffusion_model, samples = training_and_eval_pipeline(cfg)\n",
-    "samples_numpy = samples.numpy()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "raw_numpy = NER_BCI(cfg.dataset.patient_id, filepath=cfg.dataset.filepath).data_array\n",
-    "\n",
-    "assert samples_numpy.shape == raw_numpy.shape\n",
-    "num_trials, num_channels, sig_length = raw_numpy.shape\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Plot some random real and generated samples"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rand_id = np.random.randint(len(samples_numpy))\n",
-    "print(rand_id)\n",
-    "offset = -1.1\n",
-    "fig, ax = plt.subplots()\n",
-    "plot_overlapping_signal(\n",
-    "    fig,\n",
-    "    ax,\n",
-    "    sig=raw_numpy[rand_id] + offset * np.arange(num_channels)[:, np.newaxis],\n",
-    "    colors=[\"dimgrey\"],\n",
-    ")\n",
-    "basic_plotting(\n",
-    "    fig,\n",
-    "    ax,\n",
-    "    y_ticks=[],\n",
-    "    x_lim=(0, 260),\n",
-    "    x_ticks=[0, 260],\n",
-    "    x_ticklabels=[0, 1.3],\n",
-    "    x_label=\"time [s]\",\n",
-    ")\n",
-    "fig.tight_layout()\n",
-    "plt.show()\n",
-    "\n",
-    "fig, ax = plt.subplots()\n",
-    "plot_overlapping_signal(\n",
-    "    fig,\n",
-    "    ax,\n",
-    "    samples_numpy[rand_id] + offset * np.arange(num_channels)[:, np.newaxis],\n",
-    "    colors=[\"black\"],\n",
-    ")\n",
-    "basic_plotting(\n",
-    "    fig,\n",
-    "    ax,\n",
-    "    y_ticks=[],\n",
-    "    x_lim=(0, 260),\n",
-    "    x_ticks=[0, 260],\n",
-    "    x_ticklabels=[0, 1.3],\n",
-    "    x_label=\"time [s]\",\n",
-    ")\n",
-    "fig.tight_layout()\n",
-    "plt.show()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Plot the power spectral density\n",
-    "\n",
-    "For all 56 channels up until 60Hz.\n",
-    "Red is generated, black is real.\n",
-    "Pointwise median and 25% / 75% percentiles are shown."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, axs = plt.subplots(num_channels // 10 + 1, 10, figsize=(45, 25))\n",
-    "for idx in range(num_channels):\n",
-    "    plot_sd(\n",
-    "        fig=fig,\n",
-    "        ax=axs[idx // 10, idx % 10],\n",
-    "        arr_one=raw_numpy[:, idx, :],\n",
-    "        arr_two=samples_numpy[:, idx, :],\n",
-    "        fs=200,\n",
-    "        nperseg=260,\n",
-    "        agg_function=np.median,\n",
-    "        with_quantiles=True,\n",
-    "        x_ss=slice(0, 60),\n",
-    "        color_one=\"black\",\n",
-    "        color_two=\"C3\",\n",
-    "    )\n",
-    "plt.show()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Plot the evoked potentials\n",
-    "\n",
-    "For all 56 channels. Red is generated, black is real. Mean and standard deviation are shown."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, axs = plt.subplots(num_channels // 5 + 1, 5, figsize=(45, 45))\n",
-    "for idx in range(num_channels):\n",
-    "    axs[idx // 5, idx % 5].fill_between(\n",
-    "        np.arange(260),\n",
-    "        np.quantile(raw_numpy[:, idx, :], 0.1, axis=0),\n",
-    "        np.quantile(raw_numpy[:, idx, :], 0.9, axis=0),\n",
-    "        color=\"black\",\n",
-    "        alpha=0.2,\n",
-    "    )\n",
-    "    axs[idx // 5, idx % 5].fill_between(\n",
-    "        np.arange(260),\n",
-    "        np.quantile(samples_numpy[:, idx, :], 0.1, axis=0),\n",
-    "        np.quantile(samples_numpy[:, idx, :], 0.9, axis=0),\n",
-    "        color=\"C3\",\n",
-    "        alpha=0.2,\n",
-    "    )\n",
-    "    axs[idx // 5, idx % 5].plot(\n",
-    "        np.mean(raw_numpy[:, idx, :], axis=0),\n",
-    "        color=\"black\",\n",
-    "    )\n",
-    "    axs[idx // 5, idx % 5].plot(\n",
-    "        np.mean(samples_numpy[:, idx, :], axis=0),\n",
-    "        color=\"C3\",\n",
-    "    )\n",
-    "plt.show()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Plot the topomaps\n",
-    "\n",
-    "For both real and generated data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "csv_path = \"../data/CorrectedChannelsLocation.csv\"\n",
-    "chan_info = read_csv(csv_path)\n",
-    "\n",
-    "montage = mne.channels.make_standard_montage(\"standard_1020\")\n",
-    "info = mne.create_info(ch_names=list(chan_info[\"Labels\"]), sfreq=200, ch_types=\"eeg\")\n",
-    "info.set_montage(montage)\n",
-    "times = np.arange(0.15, 0.35, 0.05)\n",
-    "for samples in [raw_numpy, samples_numpy]:\n",
-    "    evoked = mne.EvokedArray(samples.mean(0), info)\n",
-    "    evoked.plot_topomap(\n",
-    "        times,\n",
-    "        ch_type=\"eeg\",\n",
-    "        scalings=1.0,\n",
-    "        vlim=(-0.5, 0.5),\n",
-    "        image_interp=\"cubic\",\n",
-    "        colorbar=False,\n",
-    "        res=300,\n",
-    "        size=1.5,\n",
-    "    )\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "neuro_diff",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.10"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "nbformat": 4,
+  "nbformat_minor": 2
 }

--- a/ntd/datasets.py
+++ b/ntd/datasets.py
@@ -71,16 +71,19 @@ class FIFDataLoader(Dataset):
     """
     Dataset loader for EEG data from .fif files.
 
-    Processes data into tensors and optionally includes subject IDs and class labels.
-    Assumes filenames follow a convention like CLASSLABEL_SUBJECTID_*.fif for label extraction.
-    `sfreq`, `n_channels`, and `n_times` (epoch length in points) are inferred from the first valid file.
-    Subsequent files must match these inferred parameters to be included.
+    Processes data into tensors and optionally includes subject IDs, class labels,
+    and a conditioning tensor that can be fed directly to conditional diffusion
+    models. Filenames are expected to follow the convention
+    ``CLASSLABEL_SUBJECTID_*.fif`` when class labels or subject IDs are requested.
+    ``sfreq``, ``n_channels``, and ``n_times`` (epoch length in points) are inferred
+    from the first valid file, and all subsequent files must match these inferred
+    parameters to be included.
     """
 
     def __init__(
         self,
         file_path,
-        n_epochs=None, # Max epochs per file. If None or 0, use all epochs from file.
+        n_epochs=None,  # Max epochs per file. If None or 0, use all epochs from file.
         condition_on_subject_id=False,
         condition_on_class_label=False,
     ):
@@ -90,20 +93,23 @@ class FIFDataLoader(Dataset):
         Args:
             file_path (str): Path to a directory of .fif files or a single .fif file.
             n_epochs (int, optional): Maximum number of epochs to use from each subject/file.
-                                     If None, 0, or greater than available epochs in a file,
-                                     all epochs from that file are used. Defaults to None.
-            condition_on_subject_id (bool): If True, extract and store subject IDs.
-            condition_on_class_label (bool): If True, extract and store class labels.
+                If None, 0, or greater than available epochs in a file, all epochs from
+                that file are used. Defaults to None.
+            condition_on_subject_id (bool): If True, extract and store subject IDs and
+                add a one-hot subject indicator to the ``cond`` tensor.
+            condition_on_class_label (bool): If True, extract and store class labels and
+                add a one-hot class indicator to the ``cond`` tensor.
         """
+
         self.file_path = file_path
-        self.n_epochs_max_per_file = n_epochs 
+        self.n_epochs_max_per_file = n_epochs
         self.condition_on_subject_id = condition_on_subject_id
         self.condition_on_class_label = condition_on_class_label
 
-        all_signals_list = [] # Renamed from all_epoch_data
+        all_signals_list = []  # Renamed from all_epoch_data
         all_subject_ids_str = []
         all_class_labels_str = []
-        
+
         self.label_to_int_id = {}
         self.next_class_int_id = 0
         self.subject_str_to_int_id = {}
@@ -137,9 +143,7 @@ class FIFDataLoader(Dataset):
                 print(f"Warning: Could not read or process {fp}. Skipping. Error: {e}")
                 continue
 
-            current_sfreq = current_epochs_object.info['sfreq']
-            # Use get_data(copy=False) if only shape is needed initially, but we need data later.
-            # Let's get data once and then derive shape.
+            current_sfreq = current_epochs_object.info["sfreq"]
             try:
                 # Picks 'eeg' and converts to float64 for consistency before potential slicing.
                 ep_data_full = current_epochs_object.get_data(picks="eeg").astype(np.float64)
@@ -159,9 +163,11 @@ class FIFDataLoader(Dataset):
                     f"sfreq={self.sfreq}, n_channels={self.n_channels}, n_times={self.n_times}"
                 )
             else:
-                if (current_sfreq != self.sfreq or
-                    current_n_channels != self.n_channels or
-                    current_n_times != self.n_times):
+                if (
+                    current_sfreq != self.sfreq
+                    or current_n_channels != self.n_channels
+                    or current_n_times != self.n_times
+                ):
                     print(
                         f"Warning: File {fp} parameters (sfreq={current_sfreq}, "
                         f"n_channels={current_n_channels}, n_times={current_n_times}) "
@@ -169,7 +175,7 @@ class FIFDataLoader(Dataset):
                         f"n_channels={self.n_channels}, n_times={self.n_times}). Skipping."
                     )
                     continue
-            
+
             # Handle n_epochs (max epochs per file)
             n_epochs_in_file = ep_data_full.shape[0]
             epochs_to_take = n_epochs_in_file
@@ -181,8 +187,8 @@ class FIFDataLoader(Dataset):
                         f"requested n_epochs={self.n_epochs_max_per_file}. Using all {n_epochs_in_file} epochs from this file."
                     )
                 epochs_to_take = min(n_epochs_in_file, self.n_epochs_max_per_file)
-            
-            if epochs_to_take == 0 : # Should not happen if n_epochs_max_per_file > 0 or None
+
+            if epochs_to_take == 0:  # Should not happen if n_epochs_max_per_file > 0 or None
                 print(f"Warning: Zero epochs selected for file {fp}. Skipping.")
                 continue
 
@@ -207,7 +213,7 @@ class FIFDataLoader(Dataset):
                     )
                     if default_class_label not in self.label_to_int_id:
                         self.label_to_int_id[default_class_label] = self.next_class_int_id
-                        self.next_class_int_id +=1
+                        self.next_class_int_id += 1
                     all_class_labels_str.extend([default_class_label] * epochs_to_take)
 
             if self.condition_on_subject_id:
@@ -228,7 +234,7 @@ class FIFDataLoader(Dataset):
                     all_subject_ids_str.extend([default_subject_id] * epochs_to_take)
         # --- End of file loop ---
 
-        if not all_signals_list: # Check if the list is empty
+        if not all_signals_list:  # Check if the list is empty
             raise ValueError(
                 "No valid EEG data loaded. Check file paths, format, and consistency of "
                 "data parameters (sfreq, n_channels, n_times) across files."
@@ -238,22 +244,49 @@ class FIFDataLoader(Dataset):
         self.data_array_np = np.concatenate(all_signals_list, axis=0)
         # Standardize data across epochs and time dimensions (mean 0, std 1)
         # ax=(0,2) standardizes each channel independently over all concatenated epochs and time points
-        self.data_array_np = standardize_array(self.data_array_np, ax=(0, 2)) 
-        self.data = torch.from_numpy(self.data_array_np).float() # Convert to float32 tensor
+        self.data_array_np = standardize_array(self.data_array_np, ax=(0, 2))
+        self.data = torch.from_numpy(self.data_array_np).float()  # Convert to float32 tensor
 
         if self.condition_on_subject_id:
             self.subject_ids = torch.tensor(
-                [self.subject_str_to_int_id[sid_str] for sid_str in all_subject_ids_str], dtype=torch.long
+                [self.subject_str_to_int_id[sid_str] for sid_str in all_subject_ids_str],
+                dtype=torch.long,
             )
         else:
-            self.subject_ids = None # Keep as None if not conditioning
+            self.subject_ids = None  # Keep as None if not conditioning
 
         if self.condition_on_class_label:
             self.class_labels = torch.tensor(
-                [self.label_to_int_id[cls_str] for cls_str in all_class_labels_str], dtype=torch.long
+                [self.label_to_int_id[cls_str] for cls_str in all_class_labels_str],
+                dtype=torch.long,
             )
         else:
-            self.class_labels = None # Keep as None if not conditioning
+            self.class_labels = None  # Keep as None if not conditioning
+
+        # Build conditioning tensors once so __getitem__ stays lightweight.
+        self.cond_dim = 0
+        cond_tensors = []
+
+        if self.condition_on_class_label:
+            class_one_hot = torch.nn.functional.one_hot(
+                self.class_labels, num_classes=len(self.label_to_int_id)
+            ).float()
+            class_cond = class_one_hot.unsqueeze(-1).repeat(1, 1, self.n_times)
+            cond_tensors.append(class_cond)
+            self.cond_dim += class_cond.shape[1]
+
+        if self.condition_on_subject_id:
+            subject_one_hot = torch.nn.functional.one_hot(
+                self.subject_ids, num_classes=len(self.subject_str_to_int_id)
+            ).float()
+            subject_cond = subject_one_hot.unsqueeze(-1).repeat(1, 1, self.n_times)
+            cond_tensors.append(subject_cond)
+            self.cond_dim += subject_cond.shape[1]
+
+        if cond_tensors:
+            self.cond = torch.cat(cond_tensors, dim=1)
+        else:
+            self.cond = None
 
     def __len__(self):
         """Returns the total number of epochs accumulated from all processed files."""
@@ -261,19 +294,23 @@ class FIFDataLoader(Dataset):
 
     def __getitem__(self, index):
         """
-        Returns a dictionary containing the signal and optional subject ID and class label for a given epoch index.
+        Returns a dictionary containing the signal and optional conditioning information for
+        a given epoch index.
 
         Args:
             index (int): Index of the epoch.
 
         Returns:
-            dict: A dictionary with 'signal', and optionally 'subject_id' and 'class_label' tensors.
+            dict: A dictionary with ``signal`` and, when requested, ``cond``, ``subject_id``,
+            and ``class_label`` tensors.
         """
         item = {"signal": self.data[index]}
         if self.condition_on_subject_id and self.subject_ids is not None:
             item["subject_id"] = self.subject_ids[index]
         if self.condition_on_class_label and self.class_labels is not None:
             item["class_label"] = self.class_labels[index]
+        if self.cond is not None:
+            item["cond"] = self.cond[index]
         return item
 
 

--- a/ntd/train_diffusion_model.py
+++ b/ntd/train_diffusion_model.py
@@ -20,6 +20,7 @@ from ntd.ajile_imputation_experiment import (
 from ntd.datasets import (
     AJILE_LFP,
     CRCNS_LFP,
+    FIFDataLoader,
     NER_BCI,
     TychoConditionalDataset,
     TychoUnconditionalDataset,
@@ -186,6 +187,13 @@ def init_dataset(cfg):
             lfp_types=cfg.dataset.lfp_types,
             signal_length=cfg.dataset.signal_length,
             filepath=cfg.dataset.filepath,
+        )
+    elif cfg.dataset.self == "fif_data":
+        data_set = FIFDataLoader(
+            file_path=cfg.dataset.file_path,
+            n_epochs=cfg.dataset.n_epochs,
+            condition_on_subject_id=cfg.dataset.condition_on_subject_id,
+            condition_on_class_label=cfg.dataset.condition_on_class_label,
         )
     elif cfg.dataset.self == "ajile":
         (


### PR DESCRIPTION
## Summary
- add conditioning support and one-hot generation to the FIFDataLoader and wire the loader into the training pipeline
- extend the example FIF dataset config with signal length, split controls, and conditioning guidance for rSEEG epochs
- refresh the example notebook to demonstrate rSEEG .fif exports, config overrides, and plotting utilities

## Testing
- python -m compileall ntd

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cac296490832ca82587d1b3bc9783)